### PR TITLE
Updated deploy auth method

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,4 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          personal_token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Updated deploy file to use GH_PAT tokeninstead of GITHUB_TOKEN